### PR TITLE
Direxists

### DIFF
--- a/fetchuuid.py
+++ b/fetchuuid.py
@@ -103,6 +103,9 @@ while keep_going:
     print("WARNING: FOR PROMPTS maker_uuid ONWARDS, DO NOT ENTER ANY DATA. PRESS RETURN.")
     print("THIS SCRIPT WILL GENERATE THESE VALUES FOR YOU.")
     
+    #delete cookiecutter's generated directory
+    shutil.rmtree(script_path + "/" + maker_name)
+    
     #generate files with cookiecutter
     cookiecutter(script_path, extra_context={'maker_uuid':maker_uuid, 'maker_name':maker_name, 'maker_desc':maker_desc, 'maker_site':maker_site})
     

--- a/fetchuuid.py
+++ b/fetchuuid.py
@@ -104,8 +104,9 @@ while keep_going:
     print("THIS SCRIPT WILL GENERATE THESE VALUES FOR YOU.")
     
     #delete cookiecutter's generated directory
-    shutil.rmtree(script_path + "/" + maker_name)
-    
+    if os.path.isdir(script_path + "/" + maker_name):
+        shutil.rmtree(script_path + "/" + maker_name)
+        
     #generate files with cookiecutter
     cookiecutter(script_path, extra_context={'maker_uuid':maker_uuid, 'maker_name':maker_name, 'maker_desc':maker_desc, 'maker_site':maker_site})
     


### PR DESCRIPTION
On second of multiple modules added (or on first if previous run aborted) the cookiecutter maker_name directory will still exist; then an error occurs. Delete that directory if it exists before calling cookiecutter.